### PR TITLE
Initialize method call in Shell

### DIFF
--- a/en/console-and-shells/shells.rst
+++ b/en/console-and-shells/shells.rst
@@ -192,6 +192,9 @@ properties attached to your shell::
 
         public function show()
         {
+            // Initialize function call is required to load the Models that are used in initialize method in Shell.
+            $this->initialize();
+            
             if (empty($this->args[0])) {
                 // Use error() before CakePHP 3.2
                 return $this->abort('Please enter a username.');


### PR DESCRIPTION
Initialize method call is required to load the models that are used in Shell. Orelse there would be an error msg.